### PR TITLE
docs: fix README and TODO typos

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -224,7 +224,7 @@ FORWARDED_ALLOW_IPS="*" gunicorn -k uvicorn.workers.UvicornWorker app:app -b 127
 Or build individual images — see [DOCKER.md](DOCKER.md).
 
 ## Auth 
-No longer uses auth. Flags to be placed in seperate area
+No longer uses auth. Flags to be placed in separate area
 
 Anon users are tracked by cookie for chat history
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,8 @@
 * ~~Chatgpt theme~~
 * ~~Chromadb integration~~
 * ~~Basic Function calling~~
-* Seperate leaderboard
-* ~~Multimodal RAG (partailly integrated)~~
+* Separate leaderboard
+* ~~Multimodal RAG (partially integrated)~~
 * ~~Cleanup some of the code~~
 * ~~Logging config~~
 * Link LLM on hugginface in README


### PR DESCRIPTION
## Problem
A few user-facing docs/TODO entries contain spelling mistakes (`seperate`, `partailly`).

## Solution
Correct the typos to `separate` and `partially` without changing meaning.

## Validation
- `git diff --check`
- `git grep -n -i -E "seperate|partailly" -- README.MD TODO.md` returns no matches

Confidence: 85/100 (docs/typo)